### PR TITLE
Expand zsh compdef patterns

### DIFF
--- a/pkg/bridges/zsh.sh
+++ b/pkg/bridges/zsh.sh
@@ -17,6 +17,7 @@ printf '%s\n' $fpath \
        -e '^_' \
        -e '^-' \
        -e '^.$' \
+       -e '^#compdef$' \
 | while IFS= read -r compdef; do
        if [[ "$compdef" == *[\[\]\*\#\(\)\|]* ]]; then
               print -rl -- ${(M)${(k)commands}:#${~compdef}}

--- a/pkg/bridges/zsh.sh
+++ b/pkg/bridges/zsh.sh
@@ -1,3 +1,5 @@
+setopt extendedglob
+
 printf '%s\n' $fpath \
 | xargs -I{} find -L {} -name '_*' 2>/dev/null \
 | xargs head -n1 2>/dev/null \
@@ -12,11 +14,15 @@ printf '%s\n' $fpath \
 | grep -v \
        -e '^$' \
        -e '=' \
-       -e '\[' \
-       -e '\*' \
-       -e '#' \
        -e '^_' \
        -e '^-' \
        -e '^.$' \
+| while IFS= read -r compdef; do
+       if [[ "$compdef" == *[\[\]\*\#\(\)\|]* ]]; then
+              print -rl -- ${(M)${(k)commands}:#${~compdef}}
+       else
+              print -r -- "$compdef"
+       fi
+done \
 | sort \
 | uniq 

--- a/pkg/bridges/zsh.sh
+++ b/pkg/bridges/zsh.sh
@@ -20,7 +20,7 @@ printf '%s\n' $fpath \
        -e '^#compdef$' \
 | while IFS= read -r compdef; do
        if [[ "$compdef" == *[\[\]\*\#\(\)\|]* ]]; then
-              print -rl -- ${(M)${(k)commands}:#${~compdef}}
+              (print -rl -- ${(M)${(k)commands}:#${~compdef}}) 2>/dev/null
        else
               print -r -- "$compdef"
        fi


### PR DESCRIPTION
Closes #261.

This updates zsh bridge command discovery so `#compdef` pattern entries are expanded against commands available in PATH instead of being discarded. Literal command entries still pass through the existing filters.

Changes:
- enable zsh extended glob matching in `zsh.sh`
- stop dropping compdef tokens that contain pattern metacharacters
- expand pattern tokens with `${(M)${(k)commands}:#${~compdef}}` and print matching command names

Validation:
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build ./cmd/carapace-bridge`
- `git diff --check`
- manually ran `pkg/bridges/zsh.sh` with a locally extracted zsh package, a fake fpath containing `#compdef (ruby|[ei]rb)[0-9.]# python[0-9.]# plain ...`, and fake PATH commands; it emitted matching commands such as `ruby`, `ruby3.2`, `erb`, `erb3`, `irb2`, `python3`, and `plain` while filtering special/private entries.
