### PR TITLE
Load fish user completions lazily

### DIFF
--- a/pkg/actions/bridge/fish.go
+++ b/pkg/actions/bridge/fish.go
@@ -26,11 +26,15 @@ func ActionFish(command ...string) carapace.Action {
 			args = append(args, c.Value)
 
 			fishConfigDir := filepath.Join(configDir, "carapace/bridge/fish")
-			if err := ensureExists(fishConfigDir + "/config.fish"); err != nil {
+			fishConfigFile := filepath.Join(fishConfigDir, "config.fish")
+			if err := ensureExists(fishConfigFile); err != nil {
 				return carapace.ActionMessage(err.Error())
 			}
 
-			snippet := fmt.Sprintf(`set __fish_config_dir %[1]q;source "$__fish_data_dir/config.fish";source %[1]q/config.fish;complete --do-complete=%[2]q`, fishConfigDir, shlex.Join(args)) // TODO needs custom escaping
+			fishCompletionDir := filepath.Join(configDir, "fish/completions")
+			completionName := filepath.Base(command[0])
+			completionFile := completionName + ".fish"
+			snippet := fmt.Sprintf(`set __fish_config_dir %[1]q;test -f "$__fish_data_dir/config.fish";and source "$__fish_data_dir/config.fish";source %[2]q;if test (complete -c %[3]q | count) -eq 0;for __carapace_fish_complete_dir in %[4]q $fish_complete_path $__fish_data_dir/completions;set -l __carapace_fish_complete_file $__carapace_fish_complete_dir/%[5]q;test -f "$__carapace_fish_complete_file";and source "$__carapace_fish_complete_file";and break;end;end;complete --do-complete=%[6]q`, fishConfigDir, fishConfigFile, completionName, fishCompletionDir, completionFile, shlex.Join(args)) // TODO needs custom escaping
 			return carapace.ActionExecCommand("fish", "--no-config", "--command", snippet)(func(output []byte) carapace.Action {
 				lines := strings.Split(string(output), "\n")
 

--- a/pkg/bridges/fish.go
+++ b/pkg/bridges/fish.go
@@ -25,9 +25,11 @@ func Fish() []string {
 			return nil, err
 		}
 
-		fishConfigPath := filepath.Join(configDir, "carapace/bridge/fish/config.fish")
+		fishConfigDir := filepath.Join(configDir, "carapace/bridge/fish")
+		fishConfigFile := filepath.Join(fishConfigDir, "config.fish")
+		fishCompletionDir := filepath.Join(configDir, "fish/completions")
 		// TODO explicitly adding $__fish_data_dir/completions which is currently missing in $fish_complete_path
-		snippet := fmt.Sprintf(`set __fish_config_dir %[1]q;source "$__fish_data_dir/config.fish";source %[1]q/config.fish;echo $fish_complete_path $__fish_data_dir/completions`, fishConfigPath)
+		snippet := fmt.Sprintf(`set __fish_config_dir %[1]q;test -f "$__fish_data_dir/config.fish";and source "$__fish_data_dir/config.fish";test -f %[2]q;and source %[2]q;echo %[3]q $fish_complete_path $__fish_data_dir/completions`, fishConfigDir, fishConfigFile, fishCompletionDir)
 
 		output, err := execlog.Command("fish", "--no-config", "--command", snippet).Output()
 		if err != nil {
@@ -35,7 +37,7 @@ func Fish() []string {
 		}
 
 		unique := make(map[string]bool)
-		for location := range strings.SplitSeq(string(output), " ") {
+		for _, location := range strings.Fields(string(output)) {
 			entries, err := os.ReadDir(location)
 			if err != nil {
 				continue


### PR DESCRIPTION
Fixes carapace-sh/carapace-bin#3149.

## Summary
- include the user fish completions directory when discovering fish bridge candidates under `--no-config`
- lazily source only the matching `<command>.fish` file before running `complete --do-complete`
- avoid re-sourcing when the bridge config already loaded completions, and trim fish path discovery output robustly

## Tests
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build -o /tmp/codex-carapace-bridge ./cmd/carapace-bridge`
- `git diff --check`
- local smoke with fish 4.7.1 standalone and temp `XDG_CONFIG_HOME`: `carapace-bridge fish demo/nushell --` returns `--config` from `fish/completions/demo.fish`
- local smoke with `CARAPACE_BRIDGES=fish carapace-bridge bridge demo/nushell --` returns the same completion and caches `["demo"]`